### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,11 @@
-%.spthy: %.m4
-	m4 $< > $@
+Q     := @
+SPTHY := ohttp.spthy
 
-.PHONY: all
-all: ohttp.spthy 
+.PHONY: all proofs clean
+all: $(SPTHY)
 
-.PHONY: proofs
-proofs:
-	tamarin-prover proofs/*
+proofs: ; $Qtamarin-prover proofs/*
 
-.PHONY: clean
-clean:
-	rm ohttp.spthy
+clean:  ; $Qrm -f $(SPTHY)
+
+%.spthy: %.m4 ; $Qm4 $< > $@


### PR DESCRIPTION
1. Add Q parameter that by default suppresses output of commands but can be overridden on the command-line

make Q=

2. Make clean work even if file is missing

3. Use a variable for the .spthy file to avoid repetition